### PR TITLE
V0.4 commands refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 # sb-shovel
 sb-shovel-output
 integration.json
+
+# Release files
+*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ CHANGED
 - Simplified command names
     - `dump` -> `pull`
     - `sendFromFile` -> `send`
-    - `emptyOne` -> `empty`
-    - `emptyAll` -> `empty -all`
+    - `emptyOne` -> `delete`
+    - `emptyAll` -> `delete -all`
 - Split `requeue` functionality from `empty`
     - Fixes [#11](https://github.com/aagoldingay/sb-shovel/issues/11) by separating incompatible concurrency
     - Requeue one message: `requeue`
     - Requeue all messages: `requeue -all`
-- Empty and Requeue all progressive output now overwrites the previous line
+- Delete and Requeue all progressive output now overwrites the previous line
 
 # 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.4
+
+ADDED
+
+- `releaseBundle.sh`
+    - Bash script to simplify the production and naming of executables
+
+CHANGED
+
+- Simplified command names
+    - `dump` -> `pull`
+    - `sendFromFile` -> `send`
+    - `emptyOne` -> `empty`
+    - `emptyAll` -> `empty -all`
+- Split `requeue` functionality from `empty`
+    - Fixes [#11](https://github.com/aagoldingay/sb-shovel/issues/11) by separating incompatible concurrency
+    - Requeue one message: `requeue`
+    - Requeue all messages: `requeue -all`
+- Empty and Requeue all progressive output now overwrites the previous line
+
 # 0.3
 
 CHANGED

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ sb-shovel.exe -cmd pull -conn "<servicebus_connection_string>" -q queueName
 Purge the contents of an entire dead-letter queue
 
 ```
-sb-shovel.exe -cmd empty -conn "<servicebus_connection_string>" -q queueName -dlq -all
+sb-shovel.exe -cmd delete -conn "<servicebus_connection_string>" -q queueName -dlq -all
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ sb-shovel
 │   LICENSE
 │   main.go
 │   README.md
+|   releaseBundle.sh
 │
 ├───.github                             # repository configurations
 │   ├───ISSUE_TEMPLATE
@@ -91,13 +92,13 @@ sb-shovel.exe -help
 Peek-dump queue contents to a local directory:
 
 ```
-sb-shovel.exe -cmd dump -conn "<servicebus_uri>" -q queueName
+sb-shovel.exe -cmd pull -conn "<servicebus_connection_string>" -q queueName
 ```
 
 Purge the contents of an entire dead-letter queue
 
 ```
-sb-shovel.exe -cmd emptyAll -conn "<servicebus_uri>" -q queueName -dlq -delay
+sb-shovel.exe -cmd empty -conn "<servicebus_connection_string>" -q queueName -dlq -all
 ```
 
 ## Testing

--- a/commands.go
+++ b/commands.go
@@ -10,7 +10,7 @@ import (
 	sbc "github.com/aagoldingay/sb-shovel/sbcontroller"
 )
 
-func dump(sb sbc.Controller, q string, dlq bool, maxWrite int) error {
+func pull(sb sbc.Controller, q string, dlq bool, maxWrite int) error {
 	err := sb.SetupSourceQueue(q, dlq, false)
 	if err != nil {
 		return err
@@ -72,7 +72,11 @@ func dump(sb sbc.Controller, q string, dlq bool, maxWrite int) error {
 	return nil
 }
 
-func empty(sb sbc.Controller, q string, dlq, all, requeue, delay bool) error {
+func requeue(sb sbc.Controller, q string, all, dlq bool) error {
+	if !dlq {
+		return fmt.Errorf("cannot requeue messages directly to a dead letter queue")
+	}
+
 	err := sb.SetupSourceQueue(q, dlq, true)
 
 	if err != nil {
@@ -80,15 +84,45 @@ func empty(sb sbc.Controller, q string, dlq, all, requeue, delay bool) error {
 	}
 	defer sb.DisconnectSource()
 
-	if requeue {
-		if !dlq {
-			return fmt.Errorf("cannot requeue messages directly to a dead letter queue")
-		}
-		err = sb.SetupTargetQueue(q, !dlq, true)
+	err = sb.SetupTargetQueue(q, !dlq, true)
+	if err != nil {
+		return fmt.Errorf("problem setting up target queue: %v", err)
+	}
+	defer sb.DisconnectTarget()
+
+	if all {
+		c, err := sb.GetSourceQueueCount()
+
 		if err != nil {
-			return fmt.Errorf("problem setting up target queue: %v", err)
+			return err
+		}
+
+		if c == 0 {
+			return fmt.Errorf("no messages to delete")
+		}
+
+		fmt.Printf("%d messages to requeue\n", c)
+		err = sb.RequeueManyMessages(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = sb.RequeueOneMessage()
+		if err != nil {
+			return err
 		}
 	}
+
+	return nil
+}
+
+func empty(sb sbc.Controller, q string, dlq, all, delay bool) error {
+	err := sb.SetupSourceQueue(q, dlq, true)
+
+	if err != nil {
+		return err
+	}
+	defer sb.DisconnectSource()
 
 	c, err := sb.GetSourceQueueCount()
 
@@ -100,23 +134,15 @@ func empty(sb sbc.Controller, q string, dlq, all, requeue, delay bool) error {
 	}
 
 	if all {
-		msgCount := "%d messages to %s\n"
-		if requeue {
-			fmt.Printf(msgCount, c, "requeue")
-		} else {
-			fmt.Printf(msgCount, c, "delete")
-		}
-	}
-
-	if all {
+		fmt.Printf("%d messages to delete\n", c)
 		eChan := make(chan error)
-		go sb.DeleteManyMessages(eChan, requeue, c, delay)
+		go sb.DeleteManyMessages(eChan, c, delay)
 
 		done := false
 		for !done {
 			e := <-eChan
 			if strings.Contains(e.Error(), "[status]") {
-				fmt.Println(e.Error())
+				fmt.Printf("\r%s", e.Error())
 				continue
 			}
 			if e.Error() != "context canceled" {
@@ -126,32 +152,16 @@ func empty(sb sbc.Controller, q string, dlq, all, requeue, delay bool) error {
 		}
 		close(eChan)
 	} else {
-		err = sb.DeleteOneMessage(requeue)
+		err = sb.DeleteOneMessage()
 		if err != nil {
 			return err
 		}
-		if requeue {
-			fmt.Println("1 message requeued")
-			sb.DisconnectTarget()
-		} else {
-			fmt.Println("1 message deleted")
-		}
+		fmt.Println("1 message deleted")
 		return nil
 	}
 
-	completeMessage := "%d message(s) %s"
+	fmt.Printf("%d message(s) deleted\n", c)
 
-	if requeue {
-		completeMessage = fmt.Sprintf(completeMessage, c, "requeued")
-	} else {
-		completeMessage = fmt.Sprintf(completeMessage, c, "deleted")
-	}
-
-	fmt.Printf("%s\n", completeMessage)
-
-	if requeue {
-		sb.DisconnectTarget()
-	}
 	return nil
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -8,10 +8,10 @@ import (
 	sbmock "github.com/aagoldingay/sb-shovel/mocks"
 )
 
-func Test_Dump_Fail_EmptyQueue(t *testing.T) {
+func Test_Pull_Fail_EmptyQueue(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 0}
 
-	err := dump(m, "testqueue", false, 5)
+	err := pull(m, "testqueue", false, 5)
 	if err == nil {
 		t.Error(err)
 	}
@@ -21,10 +21,10 @@ func Test_Dump_Fail_EmptyQueue(t *testing.T) {
 	}
 }
 
-func Test_Dump_Success_OneFile(t *testing.T) {
+func Test_Pull_Success_OneFile(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 5}
 
-	err := dump(m, "testqueue", true, 5)
+	err := pull(m, "testqueue", true, 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -51,9 +51,9 @@ func Test_Dump_Success_OneFile(t *testing.T) {
 	}
 }
 
-func Test_Dump_Success_TwoFiles(t *testing.T) {
+func Test_Pull_Success_TwoFiles(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 10}
-	err := dump(m, "testqueue", false, 5)
+	err := pull(m, "testqueue", false, 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -88,7 +88,7 @@ func Test_Dump_Success_TwoFiles(t *testing.T) {
 
 func Test_Empty_One_Fail_NoMessages(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 0}
-	err := empty(m, "testqueue", false, false, false, false)
+	err := empty(m, "testqueue", false, false, false)
 	if err.Error() != "no messages to delete" {
 		t.Error(err)
 	}
@@ -100,7 +100,7 @@ func Test_Empty_One_Fail_NoMessages(t *testing.T) {
 
 func Test_Empty_One_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 1}
-	err := empty(m, "testqueue", false, false, false, false)
+	err := empty(m, "testqueue", false, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -114,9 +114,9 @@ func Test_Empty_One_Success(t *testing.T) {
 	}
 }
 
-func Test_Empty_One_Requeue_Success(t *testing.T) {
+func Test_Requeue_One_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 1, TargetQueueCount: 0}
-	err := empty(m, "testqueue", true, false, true, false)
+	err := requeue(m, "testqueue", false, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,21 +135,17 @@ func Test_Empty_One_Requeue_Success(t *testing.T) {
 	}
 }
 
-func Test_Empty_One_Requeue_Fail_TargetDlq(t *testing.T) {
+func Test_Requeue_One_Fail_TargetDlq(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 1, TargetQueueCount: 0}
-	err := empty(m, "testqueue", false, false, true, false)
+	err := requeue(m, "testqueue", false, false)
 	if err.Error() != "cannot requeue messages directly to a dead letter queue" {
 		t.Error(err)
-	}
-
-	if m.SourceQueueClosed != true {
-		t.Error("Queue not closed")
 	}
 }
 
 func Test_Empty_All_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 10}
-	err := empty(m, "testqueue", false, true, false, false)
+	err := empty(m, "testqueue", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -163,9 +159,9 @@ func Test_Empty_All_Success(t *testing.T) {
 	}
 }
 
-func Test_Empty_All_Requeue_Success(t *testing.T) {
+func Test_Requeue_All_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 10, TargetQueueCount: 0}
-	err := empty(m, "testqueue", true, true, true, false)
+	err := requeue(m, "testqueue", true, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -184,15 +180,11 @@ func Test_Empty_All_Requeue_Success(t *testing.T) {
 	}
 }
 
-func Test_Empty_All_Requeue_Fail_TargetDlq(t *testing.T) {
+func Test_Requeue_All_Fail_TargetDlq(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 10, TargetQueueCount: 0}
-	err := empty(m, "testqueue", false, true, true, false)
+	err := requeue(m, "testqueue", true, false)
 	if err.Error() != "cannot requeue messages directly to a dead letter queue" {
 		t.Error(err)
-	}
-
-	if m.SourceQueueClosed != true {
-		t.Error("Queue not closed")
 	}
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -86,9 +86,9 @@ func Test_Pull_Success_TwoFiles(t *testing.T) {
 	}
 }
 
-func Test_Empty_One_Fail_NoMessages(t *testing.T) {
+func Test_Delete_One_Fail_NoMessages(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 0}
-	err := empty(m, "testqueue", false, false, false)
+	err := delete(m, "testqueue", false, false, false)
 	if err.Error() != "no messages to delete" {
 		t.Error(err)
 	}
@@ -98,9 +98,9 @@ func Test_Empty_One_Fail_NoMessages(t *testing.T) {
 	}
 }
 
-func Test_Empty_One_Success(t *testing.T) {
+func Test_Delete_One_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 1}
-	err := empty(m, "testqueue", false, false, false)
+	err := delete(m, "testqueue", false, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -143,9 +143,9 @@ func Test_Requeue_One_Fail_TargetDlq(t *testing.T) {
 	}
 }
 
-func Test_Empty_All_Success(t *testing.T) {
+func Test_Delete_All_Success(t *testing.T) {
 	m := &sbmock.MockServiceBusController{SourceQueueCount: 10}
-	err := empty(m, "testqueue", false, true, false)
+	err := delete(m, "testqueue", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/main.go
+++ b/main.go
@@ -8,38 +8,37 @@ import (
 )
 
 var dir, command, connectionString, queueName /*, tmpl*/ string
-var isDlq, requeue, delay, help bool
+var all, isDlq, delay, help bool
 var maxWriteCache int
-var commandList = map[string]string{"dump": "dump", "emptyOne": "emptyOne", "emptyAll": "emptyAll", "sendFromFile": "sendFromFile"}
+var commandList = map[string]bool{"empty": true, "pull": true, "requeue": true, "send": true}
 
-var version = "v0.3"
+var version = "v0.4"
 
 func outputCommands() string {
 	s := ""
-	// dump
-	s += "dump\n\tperform local file dump from queue\n\t"
+	// empty
+	s += "emptyAll\n\tremove messages from queue\n\t"
+	s += "requires: -conn, -q\n\toptional: -all, -dlq, -delay\n\t"
+	s += "WARNING: providing '-all' will delete all messages\n\t"
+	s += "WARNING: execution without '-delay' may cause issues if you are dealing with extremely large queues"
+	s += "\n"
+
+	// pull
+	s += "pull\n\tperform local file pull from queue\n\t"
 	s += "requires: -conn, -q\n\toptional: -dlq, -out-lines\n\t" // , -template
 	s += "output pattern: 'sb-shovel-output/sb_output_<file_number>'\n\t"
 	// s += "alter file pattern: -template '{{.SystemProperties.SequenceNumber}} - {{.ID}} - {{.Data | printf \"%s\"}}'"
 	s += "WARNING: local files with the same naming pattern will be overwritten"
 	s += "\n"
 
-	//emptyOne
-	s += "emptyOne\n\treceive and remove one message from queue\n\t"
-	s += "requires: -conn, -q\n\toptional: -dlq, -rq\n\t"
-	s += "WARNING: failure to provide '-rq' will result in lost messages\n\t"
-	s += "WARNING: providing -rq while actioning the main queue will point message resubmission to the dead letter queue"
+	// requeue
+	s += "requeue\n\treceive then send messages from one queue to another\n\t"
+	s += "requires: -conn, -q\n\toptional: -dlq, -all\n\t"
+	s += "WARNING: providing '-all' will delete all messages"
 	s += "\n"
 
-	//emptyAll
-	s += "emptyAll\n\treceive and remove all messages from queue\n\t"
-	s += "requires: -conn, -q\n\toptional: -dlq, -rq, -delay\n\t"
-	s += "WARNING: failure to provide '-rq' will result in lost messages\n\t"
-	s += "WARNING: execution without '-delay' may cause issues if you are dealing with extremely large queues"
-	s += "\n"
-
-	//sendFromFile
-	s += "sendFromFile\n\tsend JSON messages to a defined queue from a file\n\t"
+	// send
+	s += "send\n\tsend JSON messages to a defined queue from a file\n\t"
 	s += "requires: -conn, -q, -dir\n\toptional: -dlq\n\t"
 	s += "WARNING: max read size for a file line is 64*4096 characters\n\t"
 	s += "WARNING: ensure messages are properly formatted before sending"
@@ -53,8 +52,9 @@ func main() {
 	flag.StringVar(&command, "cmd", "", outputCommands())
 	// flag.StringVar(&tmpl, "template", `{{.Data | printf "%s"}}`, "template syntax: https://pkg.go.dev/text/template\nmessage attributes: see https://pkg.go.dev/github.com/Azure/azure-service-bus-go#Message")
 	flag.StringVar(&dir, "dir", "", "directory of file containing json messages to send")
+	flag.BoolVar(&all, "all", false, "perform the operation on an entire entity")
 	flag.BoolVar(&isDlq, "dlq", false, "point to the defined queue's deadletter subqueue")
-	flag.BoolVar(&requeue, "rq", false, "resubmit (requeue) messages")
+	// flag.BoolVar(&requeue, "rq", false, "resubmit (requeue) messages")
 	flag.BoolVar(&delay, "delay", false, "include a 250ms delay for every 50 messages sent")
 	flag.BoolVar(&help, "help", false, "information about this tool")
 	flag.IntVar(&maxWriteCache, "out-lines", 100, "number of lines per file")
@@ -73,7 +73,7 @@ func main() {
 	}
 
 	switch command {
-	case commandList["dump"]:
+	case "pull":
 		if maxWriteCache < 1 {
 			fmt.Println("Value for -out-lines is not valid. Must be >= 1")
 			return
@@ -82,28 +82,34 @@ func main() {
 			fmt.Println("Delay is not supported for this command")
 			return
 		}
-		err := dump(sb, queueName, isDlq, maxWriteCache)
+		err := pull(sb, queueName, isDlq, maxWriteCache)
 		if err != nil {
 			fmt.Println(err)
 		}
 		return
-	case commandList["emptyOne"]:
+	case "empty":
 		if delay {
 			fmt.Println("Delay is not supported for this command")
 			return
 		}
-		err := empty(sb, queueName, isDlq, false, requeue, false)
+		err := empty(sb, queueName, isDlq, all, delay)
+		// err := empty(sb, queueName, isDlq, false, requeue, false)
 		if err != nil {
 			fmt.Println(err)
 		}
 		return
-	case commandList["emptyAll"]:
-		err := empty(sb, queueName, isDlq, true, requeue, delay)
+	case "requeue":
+		// err := empty(sb, queueName, isDlq, true, requeue, delay)
+		if delay {
+			fmt.Println("Delay is not supported for this command")
+			return
+		}
+		err := requeue(sb, queueName, all, isDlq)
 		if err != nil {
 			fmt.Println(err)
 		}
 		return
-	case commandList["sendFromFile"]:
+	case "send":
 		if len(dir) == 0 {
 			fmt.Println("Value for -dir flag missing")
 			return

--- a/mocks/mockcontroller.go
+++ b/mocks/mockcontroller.go
@@ -14,18 +14,12 @@ type MockServiceBusController struct {
 	SourceQueueClosed, TargetQueueClosed bool
 }
 
-func (m *MockServiceBusController) DeleteOneMessage(requeue bool) error {
-	m.SourceQueueCount = m.SourceQueueCount - 1
-	if requeue {
-		m.TargetQueueCount++
-	}
+func (m *MockServiceBusController) DeleteOneMessage() error {
+	m.SourceQueueCount--
 	return nil
 }
 
-func (m *MockServiceBusController) DeleteManyMessages(errChan chan error, requeue bool, total int, delay bool) {
-	if requeue {
-		m.TargetQueueCount = m.SourceQueueCount
-	}
+func (m *MockServiceBusController) DeleteManyMessages(errChan chan error, total int, delay bool) {
 	m.SourceQueueCount = 0
 	errChan <- fmt.Errorf("context canceled")
 }
@@ -49,6 +43,18 @@ func (m *MockServiceBusController) ReadSourceQueue(outChan chan []string, errCha
 		msgs = []string{}
 	}
 	errChan <- errors.New(sbc.ERR_QUEUEEMPTY)
+}
+
+func (m *MockServiceBusController) RequeueOneMessage() error {
+	m.SourceQueueCount--
+	m.TargetQueueCount++
+	return nil
+}
+
+func (m *MockServiceBusController) RequeueManyMessages(total int) error {
+	m.TargetQueueCount = m.SourceQueueCount
+	m.SourceQueueCount = 0
+	return nil
 }
 
 func (m *MockServiceBusController) SendJsonMessage(q bool, data []byte) error {

--- a/mocks/mockcontroller.go
+++ b/mocks/mockcontroller.go
@@ -33,6 +33,18 @@ func (m *MockServiceBusController) DisconnectTarget() error {
 	return nil
 }
 
+func (m *MockServiceBusController) DisconnectQueues() error {
+	err := m.DisconnectSource()
+	if err != nil {
+		return err
+	}
+	err = m.DisconnectTarget()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *MockServiceBusController) ReadSourceQueue(outChan chan []string, errChan chan error, maxWrite int) {
 	msgs := []string{}
 	for i := 0; i < m.SourceQueueCount/5; i++ {

--- a/releaseBundle.sh
+++ b/releaseBundle.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# usage : ./releaseBundle.sh <version>
+
+os=("windows" "darwin" "linux")
+
+for goos in "${os[@]}"
+do
+    GOOS=$goos go build
+    filename=""
+    if [ $goos = "windows" ]; then
+        filename=".exe"
+    fi
+
+    zip "release/sb-shovel_$1_${goos}_amd64.zip" "sb-shovel$filename"
+
+    rm "sb-shovel$filename"
+done

--- a/sbcontroller/controller.go
+++ b/sbcontroller/controller.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ERR_DELETESTATUS     string = "[status] completed %d of %d messages"
+	ERR_DELETESTATUS     string = "\r[status] completed %d of %d messages"
 	ERR_NOMESSAGESTOSEND string = "no messages to send"
 	ERR_NOQUEUEOBJECT    string = "no queue to close"
 	ERR_NOTFOUND         string = "could not find service bus queue - 404"
@@ -215,7 +215,7 @@ func (sb *ServiceBusController) RequeueManyMessages(total int) error {
 	if err := sb.source.Receive(innerCtx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
 		count++
 		if count > 0 && count%50 == 0 {
-			return fmt.Errorf(ERR_DELETESTATUS, count, total)
+			fmt.Printf(ERR_DELETESTATUS, count, total)
 		}
 		if count == total {
 			err := processMessage(m)
@@ -223,6 +223,7 @@ func (sb *ServiceBusController) RequeueManyMessages(total int) error {
 				cancel()
 				return err
 			}
+			cancel()
 			return nil
 		}
 		err := processMessage(m)

--- a/sbcontroller/controller.go
+++ b/sbcontroller/controller.go
@@ -21,14 +21,16 @@ const (
 )
 
 type Controller interface {
-	DeleteOneMessage(requeue bool) error
-	DeleteManyMessages(errChan chan error, requeue bool, total int, delay bool)
+	DeleteOneMessage() error
+	DeleteManyMessages(errChan chan error, total int, delay bool)
 	DisconnectQueues() error
 	DisconnectSource() error
 	DisconnectTarget() error
 	GetSourceQueueCount() (int, error)
 	GetTargetQueueCount() (int, error)
 	ReadSourceQueue(outChan chan []string, errChan chan error, maxWrite int)
+	RequeueOneMessage() error
+	RequeueManyMessages(total int) error
 	SendJsonMessage(q bool, data []byte) error
 	SendManyJsonMessages(q bool, data [][]byte) error
 	SetupSourceQueue(name string, dlq, purge bool) error
@@ -60,14 +62,8 @@ func NewController(conn string) (Controller, error) {
 		target: nil}, nil
 }
 
-func (sb *ServiceBusController) DeleteOneMessage(requeue bool) error {
+func (sb *ServiceBusController) DeleteOneMessage() error {
 	if err := sb.source.ReceiveOne(sb.ctx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
-		if requeue {
-			err := sb.sendMessage(sb.target, m.Data)
-			if err != nil {
-				return err
-			}
-		}
 		return m.Complete(sb.ctx)
 	})); err != nil {
 		return err
@@ -75,7 +71,7 @@ func (sb *ServiceBusController) DeleteOneMessage(requeue bool) error {
 	return nil
 }
 
-func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, requeue bool, total int, delay bool) {
+func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, total int, delay bool) {
 	count := 0
 	var wg sync.WaitGroup
 
@@ -83,12 +79,6 @@ func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, requeue b
 		defer wg.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 		defer cancel()
-		if requeue {
-			err := sb.sendMessage(sb.target, m.Data)
-			if err != nil {
-				errChan <- err
-			}
-		}
 		m.Complete(ctx)
 	}
 
@@ -193,6 +183,58 @@ func (sb *ServiceBusController) ReadSourceQueue(outChan chan []string, errChan c
 		}
 		messagesOutput = append(messagesOutput, string(msg.Data))
 	}
+}
+
+func (sb *ServiceBusController) RequeueOneMessage() error {
+	if err := sb.source.ReceiveOne(sb.ctx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
+		err := sb.sendMessage(sb.target, m.Data)
+		if err != nil {
+			return err
+		}
+		return m.Complete(sb.ctx)
+	})); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sb *ServiceBusController) RequeueManyMessages(total int) error {
+	count := 0
+	processMessage := func(m *servicebus.Message) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+		err := sb.sendMessage(sb.target, m.Data)
+		if err != nil {
+			return err
+		}
+		m.Complete(ctx)
+		return nil
+	}
+
+	innerCtx, cancel := context.WithCancel(sb.ctx)
+	if err := sb.source.Receive(innerCtx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
+		count++
+		if count > 0 && count%50 == 0 {
+			return fmt.Errorf(ERR_DELETESTATUS, count, total)
+		}
+		if count == total {
+			err := processMessage(m)
+			if err != nil {
+				cancel()
+				return err
+			}
+			return nil
+		}
+		err := processMessage(m)
+		if err != nil {
+			cancel()
+			return err
+		}
+		return nil
+	})); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (sb *ServiceBusController) SendJsonMessage(q bool, data []byte) error {

--- a/sbcontroller/controller_integration_test.go
+++ b/sbcontroller/controller_integration_test.go
@@ -269,7 +269,7 @@ func Test_ServiceBusController_ReadSourceQueue_MultipleMessages_OneBatch(t *test
 	}
 
 	for i := 0; i < 5; i++ {
-		err = sb.DeleteOneMessage(false)
+		err = sb.DeleteOneMessage()
 		if err != nil {
 			t.Error(err)
 		}
@@ -340,7 +340,7 @@ func Test_ServiceBusController_ReadSourceQueue_MultipleMessages_MultipleBatches(
 	}
 
 	for i := 0; i < 10; i++ {
-		err = sb.DeleteOneMessage(false)
+		err = sb.DeleteOneMessage()
 		if err != nil {
 			t.Error(err)
 		}
@@ -390,7 +390,7 @@ func Test_ServiceBusController_Send_And_Delete_One(t *testing.T) {
 		t.Error()
 	}
 
-	err = sb.DeleteOneMessage(false)
+	err = sb.DeleteOneMessage()
 	if err != nil {
 		t.Error(err)
 	}
@@ -452,7 +452,7 @@ func Test_ServiceBusController_Send_And_Delete_Many(t *testing.T) {
 	}
 
 	eChan := make(chan error)
-	go sb.DeleteManyMessages(eChan, false, c, false)
+	go sb.DeleteManyMessages(eChan, c, false)
 
 	done := false
 	for !done {
@@ -532,7 +532,7 @@ func Test_ServiceBusController_Send_And_Delete_Trigger_Status(t *testing.T) {
 	}
 
 	eChan := make(chan error)
-	go sb.DeleteManyMessages(eChan, false, c, false)
+	go sb.DeleteManyMessages(eChan, c, false)
 
 	done := false
 	for !done {


### PR DESCRIPTION
CHANGED

- Simplified command names
    - `dump` -> `pull`
    - `sendFromFile` -> `send`
    - `emptyOne` -> `delete`
    - `emptyAll` -> `delete -all`
- Split `requeue` functionality from `empty`
    - closes #11 by separating incompatible concurrency
    - Requeue one message: `requeue`
    - Requeue all messages: `requeue -all`
- Delete and Requeue all progressive output now overwrites the previous line