### PR TITLE
tidy command; config, sbcontroller documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.6.0
+
+ADDED
+- `tidy` command
+    - Receives and identifies messages to be deleted based on a supplied regex pattern.
+    - Usage:
+        - `sb-shovel -cmd tidy -conn "servicebus_connection_string" -q testqueue -pattern "ab+c"` to run as a test.
+        - `sb-shovel -cmd tidy -conn "servicebus_connection_string" -q testqueue -pattern "ab+c" -x` to run and delete.
+    - WARNING: Using this command abandons messages that do not match, or matched messages when `-x` is not provided.
+    - Better documentation for config and sbcontroller modules.
+
+FIXED
+- `sb-shovel` help example now correctly references Service Bus connection string, rather than URI.
+
 # 0.5.0
 
 ADDED

--- a/commands_test.go
+++ b/commands_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_Config_Update_Existing(t *testing.T) {
-	cfg, err := cc.NewConfigController()
+	cfg, err := cc.NewConfigController("sb-shovel")
 	if err != nil {
 		t.Error(err)
 	}
@@ -32,7 +32,7 @@ func Test_Config_Update_Existing(t *testing.T) {
 }
 
 func Test_Config_Remove(t *testing.T) {
-	cfg, err := cc.NewConfigController()
+	cfg, err := cc.NewConfigController("sb-shovel")
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func Test_Config_Remove(t *testing.T) {
 }
 
 func Test_Config_List(t *testing.T) {
-	cfg, err := cc.NewConfigController()
+	cfg, err := cc.NewConfigController("sb-shovel")
 	if err != nil {
 		t.Error(err)
 	}
@@ -252,6 +252,53 @@ func Test_SendFromFile_Success(t *testing.T) {
 	}
 
 	if m.SourceQueueCount != 5 {
+		t.Errorf("Queue had unexpected number of messages: %d", m.SourceQueueCount)
+	}
+
+	if m.SourceQueueClosed != true {
+		t.Error("Queue not closed")
+	}
+}
+
+func Test_Tidy_Invalid_Regex(t *testing.T) {
+	m := &sbmock.MockServiceBusController{SourceQueueCount: 5}
+
+	err := tidy(m, "testqueue", "(?<", false, false)
+	if err.Error() != "error parsing regexp: invalid or unsupported Perl syntax: `(?<`" {
+		t.Error(err)
+	}
+}
+
+func Test_Tidy_No_Execute(t *testing.T) {
+	m := &sbmock.MockServiceBusController{SourceQueueCount: 5}
+
+	execute := false
+	err := tidy(m, "testqueue", "ab+c", false, execute)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if m.SourceQueueCount != 5 {
+		t.Errorf("Queue had unexpected number of messages: %d", m.SourceQueueCount)
+	}
+
+	if m.SourceQueueClosed != true {
+		t.Error("Queue not closed")
+	}
+}
+
+func Test_Tidy_Execute_Success(t *testing.T) {
+	m := &sbmock.MockServiceBusController{SourceQueueCount: 5}
+
+	execute := true
+	err := tidy(m, "testqueue", "ab+c", false, execute)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if m.SourceQueueCount != 3 {
 		t.Errorf("Queue had unexpected number of messages: %d", m.SourceQueueCount)
 	}
 

--- a/mocks/mockcontroller.go
+++ b/mocks/mockcontroller.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	sbc "github.com/aagoldingay/sb-shovel/sbcontroller"
 )
@@ -85,6 +86,15 @@ func (m *MockServiceBusController) SetupSourceQueue(name string, dlq, purge bool
 
 func (m *MockServiceBusController) SetupTargetQueue(name string, dlq, purge bool) error {
 	return nil
+}
+
+func (m *MockServiceBusController) TidyMessages(errChan chan error, rex *regexp.Regexp, execute bool, total int) {
+	if execute {
+		m.SourceQueueCount -= 2
+	}
+	errChan <- fmt.Errorf(sbc.ERR_FOUNDPATTERN, "abbc")
+	errChan <- fmt.Errorf(sbc.ERR_FOUNDPATTERN, "abbbc")
+	errChan <- fmt.Errorf("context canceled")
 }
 
 func (m *MockServiceBusController) GetSourceQueueCount() (int, error) {

--- a/sbcontroller/controller.go
+++ b/sbcontroller/controller.go
@@ -1,9 +1,13 @@
+// Package sbcontroller creates a wrapper around azure-service-bus-go to control how sb-shovel should interact with a Service Bus queue.
+//
+// As azure-service-bus-go does not expose it's own interfaces, the Controller interface was created to support Dependency Injection, allowing dependencies to mock and test logic without interacting with a queue directly.
 package sbcontroller
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +17,7 @@ import (
 
 const (
 	ERR_DELETESTATUS     string = "\r[status] completed %d of %d messages"
+	ERR_FOUNDPATTERN     string = "[status] identified %s in message"
 	ERR_NOMESSAGESTOSEND string = "no messages to send"
 	ERR_NOQUEUEOBJECT    string = "no queue to close"
 	ERR_NOTFOUND         string = "could not find service bus queue - 404"
@@ -20,6 +25,7 @@ const (
 	ERR_UNAUTHORISED     string = "unauthorised or inaccessible service bus. please confirm details - 401"
 )
 
+// Controller is a generic wrapper to control interactions with a Service Bus client.
 type Controller interface {
 	DeleteOneMessage() error
 	DeleteManyMessages(errChan chan error, total int, delay bool)
@@ -35,6 +41,7 @@ type Controller interface {
 	SendManyJsonMessages(q bool, data [][]byte) error
 	SetupSourceQueue(name string, dlq, purge bool) error
 	SetupTargetQueue(name string, dlq, purge bool) error
+	TidyMessages(errChan chan error, rex *regexp.Regexp, execute bool, total int)
 
 	closeQueue(q *servicebus.Queue) error
 	getQueueCount(q *servicebus.Queue, dlq bool) (int, error)
@@ -42,6 +49,7 @@ type Controller interface {
 	setupQueue(name string, dlq, purge bool) (*servicebus.Queue, error)
 }
 
+// ServiceBusController is the concrete implementation for the azure-service-bus-go package.
 type ServiceBusController struct {
 	Controller
 	client                   *servicebus.Namespace
@@ -50,7 +58,8 @@ type ServiceBusController struct {
 	source, target           *servicebus.Queue
 }
 
-func NewController(conn string) (Controller, error) {
+// NewServiceBusController builds and returns a ServiceBusController, initialising the azure-service-bus-go package client using a supplied connection string.
+func NewServiceBusController(conn string) (Controller, error) {
 	ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(conn))
 	if err != nil {
 		return nil, err
@@ -62,6 +71,7 @@ func NewController(conn string) (Controller, error) {
 		target: nil}, nil
 }
 
+// DeleteOneMessage receives then completes exactly ONE message from the queue. An error is returned if a problem was encountered.
 func (sb *ServiceBusController) DeleteOneMessage() error {
 	if err := sb.source.ReceiveOne(sb.ctx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
 		return m.Complete(sb.ctx)
@@ -71,6 +81,13 @@ func (sb *ServiceBusController) DeleteOneMessage() error {
 	return nil
 }
 
+// DeleteManyMessages concurrently receives and completes many messages.
+//
+// Given a total number (e.g. the current value on the queue), this process will run until that many messages have been deleted.
+//
+// Choosing to action a delay will slow down the operation per 50 messages.
+//
+// Errors are returned via a channel.
 func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, total int, delay bool) {
 	count := 0
 	var wg sync.WaitGroup
@@ -91,14 +108,11 @@ func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, total int
 				time.Sleep(250 * time.Millisecond)
 			}
 		}
-		if count == total {
-			wg.Add(1)
-			go processMessage(m)
-			cancel()
-			return nil
-		}
 		wg.Add(1)
 		go processMessage(m)
+		if count == total {
+			cancel()
+		}
 		return nil
 	})); err != nil {
 		errChan <- err
@@ -107,6 +121,7 @@ func (sb *ServiceBusController) DeleteManyMessages(errChan chan error, total int
 	wg.Wait()
 }
 
+// DisconnectQueues performs both DisconnectSource and DisconnectTarget.
 func (sb *ServiceBusController) DisconnectQueues() error {
 	err := sb.DisconnectSource()
 	if err != nil && err.Error() != ERR_NOQUEUEOBJECT {
@@ -119,6 +134,7 @@ func (sb *ServiceBusController) DisconnectQueues() error {
 	return nil
 }
 
+// DisconnectSource breaks the connection for the queue assigned to the internal source queue attribute on the Controller.
 func (sb *ServiceBusController) DisconnectSource() error {
 	if sb.source != nil {
 		return sb.closeQueue(sb.source)
@@ -126,6 +142,7 @@ func (sb *ServiceBusController) DisconnectSource() error {
 	return errors.New(ERR_NOQUEUEOBJECT)
 }
 
+// DisconnectSource breaks the connection for the queue assigned to the internal target queue attribute on the Controller.
 func (sb *ServiceBusController) DisconnectTarget() error {
 	if sb.target != nil {
 		return sb.closeQueue(sb.target)
@@ -133,14 +150,19 @@ func (sb *ServiceBusController) DisconnectTarget() error {
 	return errors.New(ERR_NOQUEUEOBJECT)
 }
 
+// GetSourceQueueCount retrieves the count of messages on the configured source queue.
 func (sb *ServiceBusController) GetSourceQueueCount() (int, error) {
 	return sb.getQueueCount(sb.source, sb.isSourceDlq)
 }
 
+// GetTargetQueueCount retrieves teh count of messages on the configured target queue.
 func (sb *ServiceBusController) GetTargetQueueCount() (int, error) {
 	return sb.getQueueCount(sb.target, sb.isTargetDlq)
 }
 
+// ReadSourceQueue peeks messages on the configured source queue, returning a batch of messages, controlled by the maxWrite variable, to a channel.
+//
+// Errors are returned on a separate channel.
 func (sb *ServiceBusController) ReadSourceQueue(outChan chan []string, errChan chan error, maxWrite int) {
 	opts := []servicebus.PeekOption{servicebus.PeekWithPageSize(100)}
 	messageIterator, err := sb.source.Peek(sb.ctx, opts...)
@@ -185,6 +207,10 @@ func (sb *ServiceBusController) ReadSourceQueue(outChan chan []string, errChan c
 	}
 }
 
+// RequeueOneMessage receives exactly ONE message from the source queue, resends the Data property of a message to the target queue,
+// then completes from the source queue.
+//
+// An error is returned if a problem was encountered.
 func (sb *ServiceBusController) RequeueOneMessage() error {
 	if err := sb.source.ReceiveOne(sb.ctx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
 		err := sb.sendMessage(sb.target, m.Data)
@@ -198,6 +224,8 @@ func (sb *ServiceBusController) RequeueOneMessage() error {
 	return nil
 }
 
+// RequeueManyMessages receives from a source queue, sends as new to the target queue, then completes from the source queue. This is performed
+// on many messages, controlled by the total parameter.
 func (sb *ServiceBusController) RequeueManyMessages(total int) error {
 	count := 0
 	processMessage := func(m *servicebus.Message) error {
@@ -217,19 +245,13 @@ func (sb *ServiceBusController) RequeueManyMessages(total int) error {
 		if count > 0 && count%50 == 0 {
 			fmt.Printf(ERR_DELETESTATUS, count, total)
 		}
-		if count == total {
-			err := processMessage(m)
-			if err != nil {
-				cancel()
-				return err
-			}
-			cancel()
-			return nil
-		}
 		err := processMessage(m)
 		if err != nil {
 			cancel()
 			return err
+		}
+		if count == total {
+			cancel()
 		}
 		return nil
 	})); err != nil {
@@ -238,6 +260,12 @@ func (sb *ServiceBusController) RequeueManyMessages(total int) error {
 	return nil
 }
 
+// SendJsonMessage sends to either the source or target queue, passing in solely the message content.
+//
+// If q is true, the message is sent to target.
+// If q is false, the message is sent to the source.
+//
+// The message is sent in JSON format.
 func (sb *ServiceBusController) SendJsonMessage(q bool, data []byte) error {
 	if !q {
 		return sb.sendMessage(sb.source, data)
@@ -245,6 +273,12 @@ func (sb *ServiceBusController) SendJsonMessage(q bool, data []byte) error {
 	return sb.sendMessage(sb.target, data)
 }
 
+// SendManyJsonMessages sends many messages, from an array, to either the source or target.
+//
+// If q is true, the message is sent to target.
+// If q is false, the message is sent to source.
+//
+// The message is sent in JSON format.
 func (sb *ServiceBusController) SendManyJsonMessages(q bool, data [][]byte) error {
 	if len(data) == 0 {
 		return errors.New(ERR_NOMESSAGESTOSEND)
@@ -258,6 +292,9 @@ func (sb *ServiceBusController) SendManyJsonMessages(q bool, data [][]byte) erro
 	return nil
 }
 
+// SetupSourceQueue configures the queue connection, by name and whether the dead letter queue should be treated as the queue.
+//
+// Specifying purge as true will increase the prefetch count for faster processing of many messages.
 func (sb *ServiceBusController) SetupSourceQueue(name string, dlq, purge bool) error {
 	var err error
 	sb.source, err = sb.setupQueue(name, dlq, purge)
@@ -265,11 +302,60 @@ func (sb *ServiceBusController) SetupSourceQueue(name string, dlq, purge bool) e
 	return err
 }
 
+// SetupTargetQueue configures the queue connection, by name and whether the dead letter queue should be treated as the queue.
+//
+// Specifying purge as true will increase the prefetch count for faster processing of many messages.
 func (sb *ServiceBusController) SetupTargetQueue(name string, dlq, purge bool) error {
 	var err error
 	sb.target, err = sb.setupQueue(name, dlq, purge)
 	sb.isTargetDlq = dlq
 	return err
+}
+
+// TidyMessages concurrently receives and identifies messages to be deleted based on a supplied regex pattern.
+//
+// WARNING: This operation will not delete messages by default. Provide execute as true to trigger deletion.
+//
+// When running without executing, matched messages are output through the error channel, and abandoned, which may result in them getting sent to the dead-letter queue.
+func (sb *ServiceBusController) TidyMessages(errChan chan error, rex *regexp.Regexp, execute bool, total int) {
+	count := 0
+	var wg sync.WaitGroup
+
+	processMessage := func(m *servicebus.Message) {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+
+		result := rex.Find(m.Data)
+
+		if string(result) == "" {
+			m.Abandon(ctx)
+			return
+		}
+
+		errChan <- fmt.Errorf(ERR_FOUNDPATTERN, string(result))
+
+		if execute {
+			m.Complete(ctx)
+		} else {
+			m.Abandon(ctx)
+		}
+	}
+
+	innerCtx, cancel := context.WithCancel(sb.ctx)
+	if err := sb.source.Receive(innerCtx, servicebus.HandlerFunc(func(c context.Context, m *servicebus.Message) error {
+		count++
+		wg.Add(1)
+		go processMessage(m)
+		if count == total {
+			cancel()
+		}
+		return nil
+	})); err != nil {
+		errChan <- err
+		return
+	}
+	wg.Wait()
 }
 
 func (sb *ServiceBusController) closeQueue(q *servicebus.Queue) error {


### PR DESCRIPTION
# 0.6.0

ADDED
- `tidy` command
    - Receives and identifies messages to be deleted based on a supplied regex pattern.
    - Usage:
        - `sb-shovel -cmd tidy -conn "servicebus_connection_string" -q testqueue -pattern "ab+c"` to run as a test.
        - `sb-shovel -cmd tidy -conn "servicebus_connection_string" -q testqueue -pattern "ab+c" -x` to run and delete.
    - WARNING: Using this command abandons messages that do not match, or matched messages when `-x` is not provided.
    - Better documentation for config and sbcontroller modules.

FIXED
- `sb-shovel` help example now correctly references Service Bus connection string, rather than URI.