### PR TITLE
19 tidy peek messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+CHANGED
+- `tidy` command
+    - Alter read-only mode to peek rather than receive messages. This avoids dead-lettering messages while testing regex or performing a "dry run".
+
 # 0.6.1
 
 FIXED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v0.6.2
 
 CHANGED
 - `tidy` command

--- a/commands.go
+++ b/commands.go
@@ -269,7 +269,7 @@ func tidy(sb sbc.Controller, q, pattern string, dlq, execute bool) error {
 			fmt.Printf("%s\n", e.Error())
 			continue
 		}
-		if e.Error() != "context canceled" {
+		if e.Error() != "context canceled" && e.Error() != sbc.ERR_QUEUEEMPTY {
 			return e
 		}
 		done = true

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var all, isDlq, delay, help, execute bool
 var maxWriteCache int
 var commandList = map[string]bool{"config": true, "delete": true, "pull": true, "requeue": true, "send": true, "tidy": true}
 
-var version = "unreleased"
+var version = "v0.6.2"
 
 func outputCommands() string {
 	s := ""

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var all, isDlq, delay, help, execute bool
 var maxWriteCache int
 var commandList = map[string]bool{"config": true, "delete": true, "pull": true, "requeue": true, "send": true, "tidy": true}
 
-var version = "v0.6.1"
+var version = "unreleased"
 
 func outputCommands() string {
 	s := ""
@@ -55,7 +55,7 @@ func outputCommands() string {
 
 	// tidy
 	s += "tidy\n\tselectively delete messages containing a regex pattern\n\t"
-	s += "requires: -conn, -q, -pattern\n\toptional: -x"
+	s += "requires: -conn, -q, -pattern\n\toptional: -x\n\t"
 	s += "WARNING: -x (execute) must be provided to delete any matching messages\n\t"
 	s += "WARNING: Using this command abandons messages that do not match, or matched messages when `-x` is not provided\n\t"
 	s += "NOTE: refer to the approved syntax: https://github.com/google/re2/wiki/Syntax"

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func outputCommands() string {
 	s += "tidy\n\tselectively delete messages containing a regex pattern\n\t"
 	s += "requires: -conn, -q, -pattern\n\toptional: -x\n\t"
 	s += "WARNING: -x (execute) must be provided to delete any matching messages\n\t"
-	s += "WARNING: Using this command abandons messages that do not match, or matched messages when `-x` is not provided\n\t"
+	s += "WARNING: Using this command abandons messages that are not matched.\n\t"
 	s += "NOTE: refer to the approved syntax: https://github.com/google/re2/wiki/Syntax"
 	// s += "\n"
 	return s

--- a/sbcontroller/controller.go
+++ b/sbcontroller/controller.go
@@ -329,7 +329,9 @@ func (sb *ServiceBusController) TidyMessages(errChan chan error, rex *regexp.Reg
 		result := rex.Find(m.Data)
 
 		if string(result) == "" {
-			m.Abandon(ctx)
+			if execute {
+				m.Abandon(ctx)
+			}
 			return
 		}
 
@@ -337,8 +339,6 @@ func (sb *ServiceBusController) TidyMessages(errChan chan error, rex *regexp.Reg
 
 		if execute {
 			m.Complete(ctx)
-		} else {
-			m.Abandon(ctx)
 		}
 	}
 

--- a/sbcontroller/controller.go
+++ b/sbcontroller/controller.go
@@ -314,9 +314,7 @@ func (sb *ServiceBusController) SetupTargetQueue(name string, dlq, purge bool) e
 
 // TidyMessages concurrently receives and identifies messages to be deleted based on a supplied regex pattern.
 //
-// WARNING: This operation will not delete messages by default. Provide execute as true to trigger deletion.
-//
-// When running without executing, matched messages are output through the error channel, and abandoned, which may result in them getting sent to the dead-letter queue.
+// WARNING: This operation will not delete messages by default. Provide execute as true to trigger deletion. Messages not matched are abandoned.
 func (sb *ServiceBusController) TidyMessages(errChan chan error, rex *regexp.Regexp, execute bool, total int) {
 	count := 0
 	var wg sync.WaitGroup

--- a/sbcontroller/controller_integration_test.go
+++ b/sbcontroller/controller_integration_test.go
@@ -622,7 +622,7 @@ func Test_ServiceBusController_TidyMessages_Success(t *testing.T) {
 		if strings.Contains(e.Error(), "[status]") {
 			continue
 		}
-		if e.Error() != "context canceled" {
+		if e.Error() != "context canceled" && e.Error() != ERR_QUEUEEMPTY {
 			t.Error(e)
 		}
 		done = true


### PR DESCRIPTION
CHANGED

- `tidy` command - closes #19 
    - Alter read-only mode to peek rather than receive messages. This avoids dead-lettering messages while testing regex or performing a "dry run".